### PR TITLE
Update 03 - Pare-feu et NAT avec nftables.md

### DIFF
--- a/EXT-TP-BASTION/03 - Pare-feu et NAT avec nftables.md
+++ b/EXT-TP-BASTION/03 - Pare-feu et NAT avec nftables.md
@@ -32,6 +32,10 @@ table inet filter {
 
     # SSH admin uniquement depuis l'hôte (192.168.88.1)
     iifname $WAN_IF ip saddr 192.168.88.1 tcp dport 22 accept
+
+    # DNS depuis la DMZ vers server1
+    iifname $DMZ_IF ip saddr $DMZ_NET udp dport 53 accept
+    iifname $DMZ_IF ip saddr $DMZ_NET tcp dport 53 accept
   }
 
   chain forward {


### PR DESCRIPTION
Ajout des règles nftables permettant aux machines de la DMZ d’interroger le DNS du serveur sur les ports 53 UDP et TCP.